### PR TITLE
fix(teamcity): add a miss picture

### DIFF
--- a/tutorials/markdown/teamcity.md
+++ b/tutorials/markdown/teamcity.md
@@ -28,7 +28,7 @@ GitHub:
 ## 安装 tcWebHooks 插件
 
 点击「Upload plugin zip」标签，选择在前面下载的插件并上传。
-![](/tutorials/image/teamcity_to_upload-page.jpg)
+![](/tutorials/image/teamcity_to_upload_page.jpg)
 ![](/tutorials/image/teamcity_upload.jpg)
 
 


### PR DESCRIPTION
修复了由于文件名写错导致的图片不显示